### PR TITLE
Add support for PHP higher than 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/hubtel/hubtel-sms-php",
     "type": "library",
     "require": {
-        "php": "^5.3"
+        "php": ">=5.3"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
I created an issue since last year regarding this and nothing was done, so I've decided to update the source. Kindly review the changes.